### PR TITLE
Don't check for a new version every admin page hit

### DIFF
--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="controller_action_predispatch">
+    <event name="backend_auth_user_login_success">
         <observer name="multisafepay_new_releases_notification"
                   instance="MultiSafepay\ConnectAdminhtml\Observer\PreDispatchAdminActionController" />
     </event>


### PR DESCRIPTION
I noticed that we were doing a lot of calls to the Github API. After investigation we found out that this was coming from the MSP module (https://github.com/MultiSafepay/magento2-core/blob/master/Util/VersionUtil.php#L65). IMHO I think that this is a bit much, although the Github API is very fast, I do not see a reason to check for a new version every (admin) page hit.

A small change would be to listen for the `backend_auth_user_login_success` event instead of `controller_action_predispatch`, now it's done only once after an user logs into the Magento 2 backend.